### PR TITLE
A few more changes to HAtester.py

### DIFF
--- a/patroni/HAtester.py
+++ b/patroni/HAtester.py
@@ -1,29 +1,50 @@
 #!/usr/bin/python3
 ############################### HAtester.py #####################################
-#     Version 2.1    Jobin Augustine 2017-2021
-# Program to test retry connection on a connection failure, 
-# Ctrl+C will result in terminating existing connection and fresh connection will be attempted
-#        This behavior is useful for testing load balancing.
-​
+#     Version 2.2    Jobin Augustine, Fernando Laudares Camargos (2017-2021)
+#
+# Program to test reads and writes in a PostgreSQL server, including
+# connection retry on connection failure to test load-balancing capabilities
+# 
 
-# This script needs  python-psycopg2 to be present in the system
-#Edit following connection string, with hostname, port and credentials
-connectionString = "host=localhost port=5000 dbname=postgres user=postgres password=vagrant connect_timeout=5"
+# PREREQUISITES
+# 1) PostgreSQL Python connector python3-psycopg2
+# 2) Target table HATEST must have been created in advance:
+#    CREATE TABLE HATEST (TM TIMESTAMP);
 
-#Execute Insert statement against table if doDML is true.
+import sys
+
+# CONNECTION DETAILS
+host = "localhost"
+dbname = "postgres"
+user = "postgres"
+password = "vagrant"
+connect_timeout = 5
+# Port number can be optionally provided as first argument
+if len(sys.argv)>1 and int(sys.argv[1]):
+  port = int(sys.argv[1])
+else:
+  port = 5432
+
+# Connection string
+connectionString = "host=%s port=%i dbname=%s user=%s password=%s connect_timeout=%i" % (host, port, dbname, user, password, connect_timeout)
+
+# Execute Insert statement against table if doDML is true.
+# create a table in advance: 
 doDML = True
 
-# create a table in advance for DML operation
-# CREATE TABLE HATEST (TM TIMESTAMP);
-
-​
-#STOP EXECUTION
-# Step 1 push the process to background : ctrl+z
-# Step 2 : pkill -9 HAtester.py
-#   OR  pgrep HAtester.py | xargs kill -9
-​
+# USAGE 
+#
+# - Execution:
+#    ./HAtester.py <port>
+#
+# - Reconnection:
+#    Ctrl+C will trigger a new connection to test load balancing.
+#
+# - Stop execution:
+#    Ctrl+Z to pause the job, then terminate it with: kill %<job_id>
+#
 ###############################################################################
-​
+
 import sys,time,psycopg2
 def create_conn():
    try:
@@ -31,9 +52,9 @@ def create_conn():
    except psycopg2.Error as e:
       print("Unable to connect to database :")
       print(e)
-      return
+      sys.exit(1)
    return conn
-​
+
 if __name__ == "__main__":
    conn = create_conn()
    if conn is not None:
@@ -49,24 +70,24 @@ if __name__ == "__main__":
             cur.execute("select pg_is_in_recovery(),inet_server_addr()")
             rows = cur.fetchone()
             if (rows[0] == False):
-               print ("Working with Master " + rows[1]),
+               print (" Working with:   MASTER - %s" % rows[1]),
                if doDML:
                   cur.execute("INSERT INTO HATEST VALUES(CURRENT_TIMESTAMP) RETURNING TM")
                   if cur.rowcount == 1 :
                      conn.commit()
                      tmrow = str(cur.fetchone()[0])
-                     print ('Inserted ' + tmrow)
+                     print ('     Inserted: %s\n' % tmrow)
                else:
-                  print (" No Attempt to insert data")
+                  print ("No Attempt to insert data")
             else:
-               print ("Working with Slave " + rows[1]),
+               print (" Working with:    REPLICA - %s" % rows[1]),
                if doDML:
                   cur.execute("SELECT MAX(TM) FROM HATEST")
                   row = cur.fetchone()
-                  print (" Retrived timestamp from database is " + str(row[0]))
+                  print ("     Retrived: %s\n" % str(row[0]))
                else:
-                  print (" No Attempt to retrive data")
-​
+                  print ("No Attempt to retrive data")
+
          except:
             print ("Trying to connect")
             if conn is not None:
@@ -74,5 +95,7 @@ if __name__ == "__main__":
             conn = create_conn()
             if conn is not None:
                  cur = conn.cursor()
-​
+
    conn.close()
+
+


### PR DESCRIPTION
Extending command execution to provide port as argument, to improve support for load-balancing tests. Modified comments section to reflect this change and better explain usage. Also made a few cosmetic changes in the printed lines, to a more concise report on the screen.

Here are two examples:

```
fernando@fernando-ThinkPad-T430s:~/Percona/tmp/pgscripts/patroni$ ./HAtester.py 5000
 Working with:   MASTER - 192.168.1.13
     Inserted: 2021-05-08 23:55:16.756446

 Working with:   MASTER - 192.168.1.13
     Inserted: 2021-05-08 23:55:17.775006

^Z
[1]+  Parado                  ./HAtester.py 5000
fernando@fernando-ThinkPad-T430s:~/Percona/tmp/pgscripts/patroni$ kill %1
[1]+  Terminado               ./HAtester.py 5000
```

```
fernando@fernando-ThinkPad-T430s:~/Percona/tmp/pgscripts/patroni$ ./HAtester.py 5001
 Working with:    REPLICA - 192.168.1.11
     Retrived: 2021-05-08 23:55:32.182450

 Working with:    REPLICA - 192.168.1.11
     Retrived: 2021-05-08 23:55:33.195154

^Z
[1]+  Parado                  ./HAtester.py 5001
fernando@fernando-ThinkPad-T430s:~/Percona/tmp/pgscripts/patroni$ kill %1

```